### PR TITLE
[FIXED JENKINS-32765] Allow the directory that plugins are exploded into to be changed

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -88,6 +88,12 @@ public class ClassicPluginStrategy implements PluginStrategy {
         }
     };
 
+    /**
+     * If set this should be the absolute file path to the the base directory for all exploded .hpi/.jpi plugins.
+     * If {@literal null} then plugins will be exploded into {@literal JENKINS_HOME/plugins}.
+     */
+    private static final String WORK_DIR = System.getProperty(ClassicPluginStrategy.class.getName() + ".WORK_DIR");
+
     private PluginManager pluginManager;
 
     /**
@@ -162,7 +168,10 @@ public class ClassicPluginStrategy implements PluginStrategy {
             if (archive.isDirectory()) {// already expanded
                 expandDir = archive;
             } else {
-                expandDir = new File(archive.getParentFile(), getBaseName(archive.getName()));
+                expandDir = WORK_DIR == null
+                        ? new File(archive.getParentFile(), getBaseName(archive.getName()))
+                        : new File(WORK_DIR, getBaseName(archive.getName()));
+                ;
                 explode(archive, expandDir);
             }
 


### PR DESCRIPTION
- This really has to be controlled by either a system property or a CLI parameter as we cannot guarantee that any path
  specified in a configuration file in JENKINS_HOME will be valid on another machine where the JENKINS_HOME is mounted
- Obviously Jenkins does not currently support fully starting two Jenkins instances on the same JENKINS_HOME, so this
  fix is to assist in Disaster Recovery (or semi-higher availability) sceanarios where the backup node is being brought
  up. In such cases, the node that failed may not have correctly released all its file handles in the backing NFS share
  and thus could be blocking the recovery node from starting up.
- An additional use case is where the JENKINS_HOME is stored on a remote disk, e.g. a SAN, etc. and the user wants to
  take advantage of the faster local disk to serve the resources from both plugins and Jenkins core. Without this change
  only Jenkins core can be relocated outside of JENKINS_HOME (using the '--webroot=...' command line option).
- Ideally we would introduce this into the extras-executable-war module once the system property has had time to soak
  (although in an ideal world that module would be agnostic of Jenkins and thus it might not be appropriate there)

@reviewbybees
